### PR TITLE
 rewrite beam type reading to support string 

### DIFF
--- a/src/main/java/net/lpcamors/optical/data/IndexedEnum.java
+++ b/src/main/java/net/lpcamors/optical/data/IndexedEnum.java
@@ -1,0 +1,64 @@
+package net.lpcamors.optical.data;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+
+public class IndexedEnum<T extends Enum<T>> {
+
+    public final boolean autoLowerCase;
+    public final Map<String, T> named;
+    public final List<T> indexed;
+
+    public IndexedEnum(boolean autoLowerCase, @SuppressWarnings("unchecked") T... values) {
+        this.autoLowerCase = autoLowerCase;
+        named = ImmutableMap.<String, T>builder()
+            .putAll(Arrays
+                .stream(values)
+                .map(e -> Map.entry(processName(e.name()), e))
+                .toList()
+            )
+            .build();
+        indexed = ImmutableList.copyOf(values);
+    }
+
+    private String processName(String name) {
+        if (autoLowerCase) {
+            return name.toLowerCase(Locale.ROOT);
+        }
+        return name;
+    }
+
+    public boolean indexInBound(int index) {
+        return index >= 0 && index < indexed.size();
+    }
+
+    public T byIndex(int index) {
+        if (!indexInBound(index)) {
+            return null;
+        }
+        return indexed.get(index);
+    }
+
+    public T byName(String name) {
+        return named.get(processName(name));
+    }
+
+    public T fromJson(JsonElement element) {
+        if (!(element instanceof JsonPrimitive primitive)) {
+            return null;
+        }
+        if (primitive.isNumber()) {
+            return byIndex(primitive.getAsInt());
+        } else if (primitive.isString()) {
+            return byName(primitive.getAsString());
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/lpcamors/optical/recipes/FocusingRecipe.java
+++ b/src/main/java/net/lpcamors/optical/recipes/FocusingRecipe.java
@@ -1,7 +1,6 @@
 package net.lpcamors.optical.recipes;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
 import com.simibubi.create.compat.jei.category.sequencedAssembly.SequencedAssemblySubCategory;
 import com.simibubi.create.content.processing.recipe.ProcessingOutput;
 import com.simibubi.create.content.processing.recipe.ProcessingRecipe;
@@ -9,12 +8,10 @@ import com.simibubi.create.content.processing.recipe.ProcessingRecipeBuilder;
 import com.simibubi.create.content.processing.sequenced.IAssemblyRecipe;
 import net.lpcamors.optical.CORecipeTypes;
 import net.lpcamors.optical.blocks.COBlocks;
-import net.lpcamors.optical.blocks.beam_focuser.BeamFocuserBlock;
 import net.lpcamors.optical.blocks.beam_focuser.BeamFocuserBlockEntity;
 import net.lpcamors.optical.compat.jei.FocusingAssemblySubcategory;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
@@ -132,12 +129,12 @@ public class FocusingRecipe extends ProcessingRecipe<RecipeWrapper> implements I
         return this.beamTypeCondition;
     }
 
-    protected FocusingRecipeParams.BeamTypeCondition readRequiredBeamType(JsonObject jsonObject){
-        if(jsonObject.has(REQUIRED_BEAM_TYPE_KEY)){
-            var r = jsonObject.get(REQUIRED_BEAM_TYPE_KEY);
-            boolean f = r.isJsonPrimitive() && ((JsonPrimitive) r).isNumber();
-            if(r instanceof JsonPrimitive j && j.isNumber() && (j.getAsInt() >= 0 && j.getAsInt() < FocusingRecipeParams.BeamTypeCondition.values().length)){
-                return FocusingRecipeParams.BeamTypeCondition.values()[r.getAsInt()];
+    protected FocusingRecipeParams.BeamTypeCondition readRequiredBeamType(JsonObject jsonObject) {
+        if (jsonObject.has(REQUIRED_BEAM_TYPE_KEY)) {
+            var got = jsonObject.get(REQUIRED_BEAM_TYPE_KEY);
+            var parsed = FocusingRecipeParams.BeamTypeCondition.INDEXED.fromJson(got);
+            if (parsed != null) {
+                return parsed;
             }
         }
         return FocusingRecipeParams.BeamTypeCondition.NONE;

--- a/src/main/java/net/lpcamors/optical/recipes/FocusingRecipeParams.java
+++ b/src/main/java/net/lpcamors/optical/recipes/FocusingRecipeParams.java
@@ -1,24 +1,17 @@
 package net.lpcamors.optical.recipes;
 
-import com.google.gson.internal.NonNullElementWrapperList;
 import com.simibubi.create.AllRecipeTypes;
-import com.simibubi.create.compat.jei.CreateJEI;
-import com.simibubi.create.compat.jei.category.CreateRecipeCategory;
-import com.simibubi.create.content.processing.recipe.HeatCondition;
 import com.simibubi.create.content.processing.recipe.ProcessingOutput;
 import com.simibubi.create.content.processing.recipe.ProcessingRecipeBuilder;
 import net.lpcamors.optical.COMod;
 import net.lpcamors.optical.blocks.optical_source.BeamHelper;
-import net.lpcamors.optical.data.FocusingRecipeGen;
-import net.minecraft.client.Minecraft;
+import net.lpcamors.optical.data.IndexedEnum;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.ItemTags;
 import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.*;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.wrapper.RecipeWrapper;
 
@@ -74,7 +67,6 @@ public class FocusingRecipeParams extends ProcessingRecipeBuilder.ProcessingReci
     }
 
     public enum BeamTypeCondition {
-
         RADIO(0, 6192150),
         MICROWAVE(1,
                 (level, itemStack) -> {
@@ -97,6 +89,8 @@ public class FocusingRecipeParams extends ProcessingRecipeBuilder.ProcessingReci
         GAMMA(3, 0x5C93E8),
         NONE(4, 0xffffff)
         ;
+
+        public static final IndexedEnum<BeamTypeCondition> INDEXED = new IndexedEnum<>(true, BeamTypeCondition.values());
 
         private final int id;
         private final BiFunction<Level, ItemStack, Boolean> bf;


### PR DESCRIPTION
- a new `IndexedEnum` class so that we can match string/number with enum values easier
- `readRequiredBeamType()` is rewritten to use `IndexedEnum#fronJson()`, which supports string->enum

Fixes #39 